### PR TITLE
Remove alchemist reviewer from PR notifications

### DIFF
--- a/notify_review.py
+++ b/notify_review.py
@@ -98,8 +98,6 @@ def get_pr_details(pr_url):
 
     if not contains_reviewer(reviewers, "@squad-eternals"):
         reviewers += ", @squad-eternals"
-    if not contains_reviewer(reviewers, "@squad-alchemist"):
-        reviewers += ", @squad-alchemist"
 
     external_reviewers = input(
         f"We already requested review to {reviewers}. Do you want to add any external reviewers (comma-separated)? "


### PR DESCRIPTION
Streamlined the reviewer list by removing "@squad-alchemist" from the automatic notifications. This adjustment helps reduce redundancy in review requests and ensures focus on the relevant squad, improving the efficiency of the review process.